### PR TITLE
Provide the ability to silence 'not running' message

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ And after some profiling requests, when the process terminates, you can visit th
 [tunemygc, pid: 70160] Please visit https://tunemygc.com/configs/d739119e4abc38d42e183d1361991818 to view your configuration and other Garbage Collector insights
 ```
 
+* `RUBY_GC_TUNE_VERBOSE=0`
+
+In some environments (such as CI) you do not want the gem to be outputting the
+"not running" message as this can pollute your log data. If you'd like to
+silence the output, you can set `RUBY_GC_TUNE_VERBOSE=0` and it will not output
+the message.
+
 #### Advanced
 
 * `RUBY_GC_SPY=action_controller` (Spy on the GC for this type of processing. `action_controller`, `active_job`, `delayed_job`, `que_job`, `minitest` or `rspec` are supported)

--- a/lib/tunemygc.rb
+++ b/lib/tunemygc.rb
@@ -15,6 +15,10 @@ module TuneMyGc
   def self.rails_version
     rails? ? Rails.version : "0.0"
   end
+
+  def self.run_silently?
+    !ENV['RUBY_GC_TUNE_VERBOSE'].nil? && ENV['RUBY_GC_TUNE_VERBOSE'].to_i == 0
+  end
 end
 
 if ENV["RUBY_GC_TUNE"] && ENV["RUBY_GC_TUNE"] != ""
@@ -27,5 +31,5 @@ if ENV["RUBY_GC_TUNE"] && ENV["RUBY_GC_TUNE"] != ""
     TuneMyGc.booted
   end
 else
-  puts "[tunemygc] not enabled"
+  puts "[tunemygc] not enabled" unless TuneMyGc.run_silently?
 end


### PR DESCRIPTION
Not all environments need the 'not running' message so this provides the ability
to silence that output for environments where it it not required by using
`RUBY_GC_TUNE_VERBOSE=0` as an environment option.