### PR TITLE
Contributions?

### DIFF
--- a/ext/tunemygc/tunemygc_ext.c
+++ b/ext/tunemygc/tunemygc_ext.c
@@ -58,7 +58,10 @@ static void tunemygc_gc_hook_i(VALUE tpval, void *data)
     rb_trace_arg_t *tparg = rb_tracearg_from_tracepoint(tpval);
     rb_event_flag_t flag = rb_tracearg_event_flag(tparg);
 
-    tunemygc_stat_record *stat = ((tunemygc_stat_record*)malloc(sizeof(tunemygc_stat_record)));
+    tunemygc_stat_record *stat = ((tunemygc_stat_record*)calloc(1, sizeof(tunemygc_stat_record)));
+    if (!stat) {
+      return;
+    }
     if (rb_thread_current() == rb_thread_main()) {
       stat->thread_id = Qnil;
     } else {

--- a/ext/tunemygc/tunemygc_ext.c
+++ b/ext/tunemygc/tunemygc_ext.c
@@ -18,7 +18,7 @@ static double _tunemygc_walltime()
 {
   struct timespec ts;
 #ifdef HAVE_CLOCK_GETTIME
-  if (clock_gettime(CLOCK_REALTIME, &ts) == -1) {
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1) {
     rb_sys_fail("clock_gettime");
   }
 #else


### PR DESCRIPTION
👋 Hi there. 
This is a (first) follow up on #39, that I accidentally had opened against your repo... 
Here are some 2 simple changesets:
 - 3f0a2e7 that uses `CLOCK_MONOTONIC` in order to get precise, _in our case_, it's used to measure durations of individual GC cycles. I understand this may not be desired in other cases, though I have a hard time seeing which as well to be honest... I could parameterize what clock to use as well.
 - 4f61ec6 `calloc` vs. `malloc` and checks the actual allocation succeeded.

I have further changes I can clean up, let me know which make sense: 
 - [x] Support other GC events (`RUBY_INTERNAL_EVENT_GC_ENTER` & `_GC_EXIT`). They'd be reported in "bursts", but ordered. I can make this conditionally be the case, i.e. that they only get reported when explicitly asked for (creates quite a few events!)
 - [x] Introduce a "consumer" function to the `TuneMyGc::Snapshotter`, that enables one to consume the snapshots, rather than buffering them (because of what they amount to when listening to all GC events). 
 - [x] Finally I had issues with some logging (when the buffer was full) sometimes, where some mutex couldn't be acquired. I may need to look into that one again, to refresh my memory…

Anyways, let me know of such things are of interest. They certainly were helpful to us... And thanks for the work!
